### PR TITLE
GHC Track typo

### DIFF
--- a/content/zurihac2019/sections/contact.html
+++ b/content/zurihac2019/sections/contact.html
@@ -29,7 +29,7 @@
     <ul>
       <li><strong>Main Organizers</strong>: Jasper Van der Jeugt, Juri Chome, Farhad Mehta</li>
       <li><strong>Beginner Track</strong>: Nicolas Gagliani, Martin Huschenbett</li>
-      <li><strong>GHC DevOps Track</strong>: Andreas Herrmann, Niklas Hambüchen</li>
+      <li><strong>GHC Track</strong>: Andreas Herrmann, Niklas Hambüchen</li>
       <li><strong>T-Shirts</strong>: Carl Baatz</li>
       <li><strong>Sponsoring</strong>: Silvio Böhler</li>
       <li><strong>HSR Location and Facilities</strong>: Ingrid Vettiger, Farhad Mehta</li>

--- a/content/zurihac2019/sections/program.html
+++ b/content/zurihac2019/sections/program.html
@@ -380,7 +380,7 @@
     </li>
     <li>
       <strong>Matthew Pickering</strong>:
-      working with tools such as tools such as ghc-artefact-nix,
+      working with tools such as ghc-artefact-nix,
       haskell-ide-engine, ghcid, GHC's debugger whilst working on GHC.
     </li>
   </ul>


### PR DESCRIPTION
Fixing a typo in the GHC track and `GHC DevOps Track -> GHC Track`.