### PR TITLE
Remove inkscape dependency, just use SVGs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,6 @@ env:
   global:
   - PATH="$HOME/.local/bin/:$PATH"
 
-addons:
-  apt:
-    packages:
-    - inkscape
-
 cache:
   directories:
   - '$HOME/.stack'

--- a/content/zurihac2019/sections/sponsors.html
+++ b/content/zurihac2019/sections/sponsors.html
@@ -13,7 +13,7 @@
   </a>
 
   <a href="https://www.fretlink.com/" target="_blank">
-    <img alt="Fretlink" src="/images/s43/fretlink.png">
+    <img alt="Fretlink" src="/images/s43/fretlink.svg">
   </a>
 
   <a href="https://developers.google.com/open-source/" target="_blank">
@@ -29,7 +29,8 @@
   </a>
 
   <a href="https://www.hsr.ch/en" target="_blank">
-    <img alt="HSR" src="/images/s43/hsr.png">
+    <!-- This SVG needs explit width / height. -->
+    <img width="180px" height="60px" alt="HSR" src="/images/s43/hsr.svg">
   </a>
 
   <a href="https://www.myrtle.ai/" target="_blank">
@@ -38,11 +39,11 @@
     <img style="width: 100px; height: 100px;
                 max-width: initial; max-height: initial;
                 margin-bottom: -10px;"
-        alt="myrtle.ai" src="/images/s43/myrtle.png">
+        alt="myrtle.ai" src="/images/s43/myrtle.svg">
   </a>
 
   <a href="https://serokell.io/" target="_blank">
-    <img alt="Serokell" src="/images/s43/serokell.png">
+    <img alt="Serokell" src="/images/s43/serokell.svg">
   </a>
 
   <a href="https://tezos.com/" target="_blank">
@@ -59,7 +60,7 @@
   </a>
 
   <a href="https://www.well-typed.com/" target="_blank">
-    <img alt="Well-Typed" src="/images/s43/well-typed.png">
+    <img alt="Well-Typed" src="/images/s43/well-typed.svg">
   </a>
 
   <p>

--- a/content/zurihac2020/sections/sponsors.html
+++ b/content/zurihac2020/sections/sponsors.html
@@ -9,19 +9,20 @@
 
   <a href="https://iohk.io/" target="_blank"><img alt="IOHK" src="/images/s43/iohk.png"></a>
 
-  <a href="https://www.fretlink.com/" target="_blank"><img alt="Fretlink" src="/images/s43/fretlink.png"></a>
+  <a href="https://www.fretlink.com/" target="_blank"><img alt="Fretlink" src="/images/s43/fretlink.svg"></a>
 
   <a href="https://developers.google.com/open-source/" target="_blank"><img alt="Google" src="/images/s43/google.png"></a>
 
-  <a href="https://www.hackworthltd.uk/" target="_blank"><img alt="Hackworth" src="/images/s43/hackworth.png"></a>
+  <a href="https://www.hackworthltd.uk/" target="_blank"><img alt="Hackworth" src="/images/s43/hackworth.svg"></a>
 
-  <a href="https://www.hsr.ch/en" target="_blank"><img alt="HSR" src="/images/s43/hsr.png"></a>
+  <!-- This SVG needs explit width / height. -->
+  <a href="https://www.hsr.ch/en" target="_blank"><img width="180px" height="60px" alt="HSR" src="/images/s43/hsr.svg"></a>
 
-  <a href="https://serokell.io/" target="_blank"><img alt="Serokell" src="/images/s43/serokell.png"></a>
+  <a href="https://serokell.io/" target="_blank"><img alt="Serokell" src="/images/s43/serokell.svg"></a>
 
   <a href="https://www.tweag.io/" target="_blank"><img alt="Tweag I/O" src="/images/s43/tweag.png"></a>
 
-  <a href="https://www.well-typed.com/" target="_blank"><img alt="Well-Typed" src="/images/s43/well-typed.png"></a>
+  <a href="https://www.well-typed.com/" target="_blank"><img alt="Well-Typed" src="/images/s43/well-typed.svg"></a>
 
   <p>
     Interested in sponsoring?  <a href="mailto:zurihac@zfoh.ch">Contact us!</a>

--- a/css/zurihac2019.css
+++ b/css/zurihac2019.css
@@ -358,9 +358,9 @@ a {
   margin: 12px;
 }
 
-.speaker .links .github  {background: url("/images/icons/github.png");  background-size: 24px 24px;}
-.speaker .links .twitter {background: url("/images/icons/twitter.png"); background-size: 24px 24px;}
-.speaker .links .web     {background: url("/images/icons/globe.png");   background-size: 24px 24px;}
+.speaker .links .github  {background: url("/images/icons/github.svg");  background-size: 24px 24px;}
+.speaker .links .twitter {background: url("/images/icons/twitter.svg"); background-size: 24px 24px;}
+.speaker .links .web     {background: url("/images/icons/globe.svg");   background-size: 24px 24px;}
 
 footer {
   font-size: 12px;

--- a/css/zurihac2020.css
+++ b/css/zurihac2020.css
@@ -242,9 +242,9 @@ nav:not(:target) {
   margin-bottom: 12px;
 }
 
-.speaker .links .github  {background: url("/images/icons/github.png");  background-size: 24px 24px;}
-.speaker .links .twitter {background: url("/images/icons/twitter.png"); background-size: 24px 24px;}
-.speaker .links .web     {background: url("/images/icons/globe.png");   background-size: 24px 24px;}
+.speaker .links .github  {background: url("/images/icons/github.svg");  background-size: 24px 24px;}
+.speaker .links .twitter {background: url("/images/icons/twitter.svg"); background-size: 24px 24px;}
+.speaker .links .web     {background: url("/images/icons/globe.svg");   background-size: 24px 24px;}
 
 /*******************************************************************************
  * Sponsors */

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -4,18 +4,13 @@ import           Data.Monoid      ((<>))
 import qualified Data.Time        as Time
 import           Hakyll
 import           Meetup
-import           System.Exit      (ExitCode (..))
 import           System.FilePath  (joinPath, splitPath)
-import qualified System.Process   as Process
 
 main :: IO ()
 main = hakyll $ do
 
     ----------------------------------------------------------------------------
     -- Images, CSS, etc.
-
-    match "images/s43/*.svg" $ inkscapeRules (Nothing, Just 180)
-    match "images/icons/*.svg" $ inkscapeRules (Just 64, Just 64)
 
     match ("images/**.png" .||. "images/**.jpg" .||. "images/**.gif" .||. "images/**.svg") $ do
         route idRoute
@@ -107,25 +102,6 @@ main = hakyll $ do
     -- Templates.
 
     match "templates/*.html" $ compile templateCompiler
-
-inkscapeRules :: (Maybe Int, Maybe Int) -> Rules ()
-inkscapeRules wh = do
-    route $ setExtension "png"
-    compile $ inkscapeCompiler wh
-
-inkscapeCompiler :: (Maybe Int, Maybe Int) -> Compiler (Item TmpFile)
-inkscapeCompiler (w, h) = do
-    filePath          <- toFilePath <$> getUnderlying
-    png@(TmpFile tmp) <- newTmpFile "inkscape"
-    exitCode <- unsafeCompiler $ Process.rawSystem "inkscape" $
-        ["-e", tmp] ++
-        (case w of Nothing -> []; Just w' -> ["-w", show w']) ++
-        (case h of Nothing -> []; Just h' -> ["-h", show h']) ++
-        [filePath]
-    case exitCode of
-        ExitSuccess   -> return ()
-        ExitFailure e -> fail $ "inkscape exit code " ++ show e
-    makeItem png
 
 sectionContext :: Context String
 sectionContext =


### PR DESCRIPTION
The inkscape dependency was used to convert some images (github/twitter/website
logos for speakers and sponsor logos) from SVG to PNG.  However, it proves to
be an annoying dependency on Mac OS X.

This patch changes just makes the website use the SVGs directly.  It seems to
work fine in Firefox and Chromium.  I had to set an explicit width/height for
the HSR logo only.