### PR TITLE
Add Curry Language Server

### DIFF
--- a/content/zurihac2020/projects.json
+++ b/content/zurihac2020/projects.json
@@ -731,5 +731,17 @@
       },
       "contact": "Tom Ellis",
       "description": "Opaleye Hackathon: work on Opaleye, a composable Postgres embedded relational query language"
+    },
+    {
+      "id": "curry-language-server",
+      "name": "Curry Language Server",
+      "link": "https://github.com/fwcd/curry-language-server.git",
+      "contributor level": {
+        "beginner": false,
+        "intermediate": true,
+        "advanced": true
+      },
+      "contact": "Fredrik Wieczerkowski",
+      "description": "An IDE-backend for the Haskell-like functional logic language Curry"
     }
   ]


### PR DESCRIPTION
Add the [curry-language-server](https://github.com/fwcd/curry-language-server), an IDE-backend for the functional logic language [Curry](https://en.wikipedia.org/wiki/Curry_(programming_language)) to the list of projects.