### PR TITLE
Fix invalid JSON in projects.json

### DIFF
--- a/content/zurihac2020/projects.json
+++ b/content/zurihac2020/projects.json
@@ -823,7 +823,7 @@
       "contributor level": {
         "beginner": true,
         "intermediate": true,
-        "advanced": true,
+        "advanced": true
       },
       "contact": "Gabriel Gonzalez",
       "description": "Improve the Haskell implementation of Dhall, especially issues with the ZuriHac label"


### PR DESCRIPTION
https://zfoh.ch/zurihac2020/projects.html is currently broken – presumably because of that trailing comma.