### PR TITLE
fix broken link to sarsi

### DIFF
--- a/content/zurihac2021/projects.json
+++ b/content/zurihac2021/projects.json
@@ -230,7 +230,7 @@
   {
     "id": "sarsi",
     "name": "sarsi",
-    "link": "github.com/aloiscochard/sarsi",
+    "link": "https://github.com/aloiscochard/sarsi",
     "contributor level": {
       "beginner": true,
       "intermediate": false,


### PR DESCRIPTION
cause it pointed to https://zfoh.ch/zurihac2021/github.com/aloiscochard/sarsi