### PR TITLE
Add a section on scholarships

### DIFF
--- a/content/zurihac2023/index.html
+++ b/content/zurihac2023/index.html
@@ -175,40 +175,42 @@
     free event, but transportation, lodging, and food might discourage somebody
     without a good income from attending. We want to make it easier for anyone
     to come, and contribute towards making the Haskell community exciting and
-    diverse.
+    diverse.  For that reason, we will provide a small number of scholarships.
   </p>
-  <p>
-    For that reason, we will provide a small number of scholarships. Because we
-    do not charge anything for tickets, our budget is limited, so we'll
-    distribute them on a first come, first serve basis. Anybody accepted will
-    be supported with an amount between 100.- and 500.- Swiss Francs, depending
-    on your expenses.
-  </p>
-  <p>
-    Our focus is on people with limited financial means and underrepresented
-    groups in tech -- the latter includes, but is not limited to: people of
-    color, anyone identifying as LGBTQIA+, women, and disabled people.
-  </p>
-  <p>
-    You can apply by sending an email to scholarships@zfoh.ch, and tell us why
-    you are interested in joining the event and how a scholarship would help?
-    Don't write an essay, a couple of sentences are enough :)
-  </p>
-  <p>
-    After we confirm your scholarship, please book your transport and
-    accommodation, and send us the receipts and IBAN information for the wire
-    transfer. Once we get your receipts, we'll wire you the money.
-  </p>
-  <p>
-    We will not disclose the recipients of these scholarships, in order to
-    protect their privacy. The amount you estimate for your expenses will not
-    be a factor when we consider your application.
-  </p>
-  <p>
-    Don't be shy and just contact us if you feel that this can make a
-    difference to you. There is no downside to applying, and we will never
-    disclose your identity.
-  </p>
+  <details>
+    <summary>What does this involve?  How do I apply?</summary>
+    <p>
+      Because we do not charge anything for tickets, our budget is limited,
+      so we'll distribute the scholarships on a first come, first serve
+      basis. Anybody accepted will be supported with an amount between 100.- and
+      500.- Swiss Francs, depending on your expenses.
+    </p>
+    <p>
+      Our focus is on people with limited financial means and underrepresented
+      groups in tech—the latter includes, but is not limited to: people of
+      color, anyone identifying as LGBTQIA+, women, and disabled people.
+    </p>
+    <p>
+      You can apply by sending an email to scholarships@zfoh.ch, and tell us why
+      you are interested in joining the event and how a scholarship would help?
+      Don't write an essay, a couple of sentences are enough.
+    </p>
+    <p>
+      After we confirm your scholarship, please book your transport and
+      accommodation, and send us the receipts and IBAN information for the wire
+      transfer. Once we get your receipts, we'll wire you the money.
+    </p>
+    <p>
+      We will not disclose the recipients of these scholarships, in order to
+      protect their privacy. The amount you estimate for your expenses will not
+      be a factor when we consider your application.
+    </p>
+    <p>
+      Don't be shy and just contact us if you feel that this can make a
+      difference to you. There is no downside to applying, and we will never
+      disclose your identity.
+    </p>
+  </details>
 </section>
 
 <h1>About</h1>

--- a/content/zurihac2023/index.html
+++ b/content/zurihac2023/index.html
@@ -167,6 +167,50 @@
   </p>
 </section>
 
+<h1>Support</h1>
+<section>
+  <h2 id="scholarships">Scholarships</h2>
+  <p>
+    Switzerland can be expensive for people visiting from abroad. ZuriHac is a
+    free event, but transportation, lodging, and food might discourage somebody
+    without a good income from attending. We want to make it easier for anyone
+    to come, and contribute towards making the Haskell community exciting and
+    diverse.
+  </p>
+  <p>
+    For that reason, we will provide a small number of scholarships. Because we
+    do not charge anything for tickets, our budget is limited, so we'll
+    distribute them on a first come, first serve basis. Anybody accepted will
+    be supported with an amount between 100.- and 500.- Swiss Francs, depending
+    on your expenses.
+  </p>
+  <p>
+    Our focus is on people with limited financial means and underrepresented
+    groups in tech -- the latter includes, but is not limited to: people of
+    color, anyone identifying as LGBTQIA+, women, and disabled people.
+  </p>
+  <p>
+    You can apply by sending an email to scholarships@zfoh.ch, and tell us why
+    you are interested in joining the event and how a scholarship would help?
+    Don't write an essay, a couple of sentences are enough :)
+  </p>
+  <p>
+    After we confirm your scholarship, please book your transport and
+    accommodation, and send us the receipts and IBAN information for the wire
+    transfer. Once we get your receipts, we'll wire you the money.
+  </p>
+  <p>
+    We will not disclose the recipients of these scholarships, in order to
+    protect their privacy. The amount you estimate for your expenses will not
+    be a factor when we consider your application.
+  </p>
+  <p>
+    Don't be shy and just contact us if you feel that this can make a
+    difference to you. There is no downside to applying, and we will never
+    disclose your identity.
+  </p>
+</section>
+
 <h1>About</h1>
 <section>
   <h2 id="contact">Contact</h2>

--- a/css/zurihac2023.css
+++ b/css/zurihac2023.css
@@ -95,6 +95,14 @@ footer {
     animation: retrogradient 1s linear infinite;
 }
 
+summary {
+    color: var(--highlights0);
+    font-weight: bold;
+    padding-left: 2em;
+    text-align: left;
+    text-decoration: underline;
+}
+
 @keyframes retrogradient {
     0% {
         background-position: 0px 0px;


### PR DESCRIPTION
I based the content on previous year's section on scholarships. Last year it was listed as part of the registration section. But, this year the registration link was moved to the very top of the page into a top-level structure. So, I added a dedicated section called "Support". Let me know if you can think of a better place to fit this into the page.
