### PR TITLE
Add GHC SIMD project

### DIFF
--- a/content/zurihac2024/projects/projects.json
+++ b/content/zurihac2024/projects/projects.json
@@ -110,6 +110,16 @@
     }
   },
   {
+   "name": "GHC SIMD in the NCG",
+   "contact": "Sam Derbyshire",
+   "description": "Adding SIMD support to GHC's NCG",
+   "link": "https://gitlab.haskell.org/ghc/ghc/-/wikis/SIMD-NCG",
+   "contributorLevel": {
+     "beginner": false,
+     "intermediate": true,
+     "advanced": true
+  },
+  {
     "name": "ghcup",
     "contact": "Julian Ospald",
     "description": "https://github.com/haskell/ghcup-hs/issues/65",


### PR DESCRIPTION
This commit adds a new project that consists of adding SIMD support to GHC's native code generator (NCG). This would lift the requirement to use LLVM to get SIMD support when writing Haskell code.

Current status of the project is tracked [on the GHC wiki](https://gitlab.haskell.org/ghc/ghc/-/wikis/SIMD-NCG).