### PR TITLE
ZuriHac og:descriptions: "haskell" → "Haskell"

### DIFF
--- a/templates/zurihac2020.html
+++ b/templates/zurihac2020.html
@@ -10,7 +10,7 @@
     <meta property="og:title" content="ZuriHac 2020" />
     <meta
       property="og:description"
-      content="ZuriHac is a free annual haskell event brought to you by «Zürich Friends of Haskell»"
+      content="ZuriHac is a free annual Haskell event brought to you by «Zürich Friends of Haskell»"
     />
     <meta
       property="og:image"
@@ -20,7 +20,7 @@
     <meta name="twitter:title" content="ZuriHac 2020" />
     <meta
       name="twitter:description"
-      content="ZuriHac is a free annual haskell event brought to you by «Zürich Friends of Haskell»"
+      content="ZuriHac is a free annual Haskell event brought to you by «Zürich Friends of Haskell»"
     />
     <meta
       name="twitter:image"

--- a/templates/zurihac2021.html
+++ b/templates/zurihac2021.html
@@ -9,12 +9,12 @@
 
   <meta property="og:title" content="ZuriHac 2021" />
   <meta property="og:description"
-    content="ZuriHac is a free annual haskell event brought to you by «Zürich Friends of Haskell»" />
+    content="ZuriHac is a free annual Haskell event brought to you by «Zürich Friends of Haskell»" />
   <meta property="og:image" content="https://zfoh.ch/images/zurihac2021/header.png" />
 
   <meta name="twitter:title" content="ZuriHac 2021" />
   <meta name="twitter:description"
-    content="ZuriHac is a free annual haskell event brought to you by «Zürich Friends of Haskell»" />
+    content="ZuriHac is a free annual Haskell event brought to you by «Zürich Friends of Haskell»" />
   <meta name="twitter:image" content="https://zfoh.ch/images/zurihac2021/header.png" />
 
   <meta name="twitter:card" content="summary" />

--- a/templates/zurihac2022.html
+++ b/templates/zurihac2022.html
@@ -6,7 +6,7 @@
 
     <meta property="og:title" content="ZuriHac 2022" />
     <meta property="og:description"
-        content="ZuriHac is a free annual haskell event brought to you by «Zürich Friends of Haskell»" />
+        content="ZuriHac is a free annual Haskell event brought to you by «Zürich Friends of Haskell»" />
     <meta property="og:image" content="https://zfoh.ch/images/zurihac2022/static.png" />
 
 

--- a/templates/zurihac2023.html
+++ b/templates/zurihac2023.html
@@ -6,7 +6,7 @@
 
     <meta property="og:title" content="ZuriHac 2023" />
     <meta property="og:description"
-        content="ZuriHac is a free annual haskell event brought to you by «Zürich Friends of Haskell»" />
+        content="ZuriHac is a free annual Haskell event brought to you by «Zürich Friends of Haskell»" />
     <meta property="og:image" content="https://zfoh.ch/images/zurihac2023/preview.png" />
 
 

--- a/templates/zurihac2024.html
+++ b/templates/zurihac2024.html
@@ -6,7 +6,7 @@
 
     <meta property="og:title" content="ZuriHac 2024" />
     <meta property="og:description"
-        content="ZuriHac is a free annual haskell event brought to you by «Zürich Friends of Haskell»" />
+        content="ZuriHac is a free annual Haskell event brought to you by «Zürich Friends of Haskell»" />
     <meta property="og:image" content="https://zfoh.ch/images/zurihac2024/preview.jpg" />
 
     <title>ZuriHac 2024</title>


### PR DESCRIPTION
Write "Haskell" with an initial uppercase letter in the `og:description`s, as it's a proper noun.