### PR TITLE
remove former IFS interns from additional key people

### DIFF
--- a/content/zurihac2026/index.html
+++ b/content/zurihac2026/index.html
@@ -629,10 +629,8 @@
     Jeremy Stucki,
     John Rodewald,
     Lukas Buchli,
-    Mario Aeberhard,
     Olivier Lischer,
-    Raphael Das Gupta,
-    Silvan Hegner, and
+    Raphael Das Gupta, and
     Vaibhav Sagar.
   </p>
   <p>


### PR DESCRIPTION
The interns previously referenced no longer work at the Institute for Software and are not helping with the ZuriHac 2026