### PR TITLE
Add WireCat to the list of projects

### DIFF
--- a/content/zurihac2026/projects/projects.json
+++ b/content/zurihac2026/projects/projects.json
@@ -242,6 +242,17 @@
     }
   },
   {
+    "name": "WireCat",
+    "contact": "Juan Raphael Diaz Simões",
+    "description": "WireCat: visual programming with cartesian categories",
+    "link": "https://github.com/guaraqe/wirecat",
+    "contributorLevel": {
+      "beginner": false,
+      "intermediate": true,
+      "advanced": true
+    }
+  },
+  {
     "name": "bsc",
     "contact": "Lucas Kramer",
     "description": "Compiler for the Bluespec hardware description language",


### PR DESCRIPTION
Add WireCat to the list of projects one can work on in ZuriHac 2026.